### PR TITLE
Secret-scan test fixtures: vulnerable credential endpoints (scanner test environment)

### DIFF
--- a/.github/workflows/vulnerable-deploy.yml
+++ b/.github/workflows/vulnerable-deploy.yml
@@ -1,0 +1,55 @@
+# INTENTIONALLY VULNERABLE — Test fixture for CI/CD exploitation assessment
+# All credentials are FAKE/SYNTHETIC test values
+name: Vulnerable Deploy Pipeline
+
+on:
+  pull_request_target:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  # SCENARIO 9: AWS credentials hardcoded in CI/CD (→ CRITICAL, CI_CD_CONTEXT)
+  AWS_ACCESS_KEY_ID: AKIAZTESTCICDKEY0001
+  AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYCICDTESTKEY
+  # SCENARIO 10: Jira token in CI/CD (→ HIGH, CI_CD_CONTEXT)
+  JIRA_TOKEN: ATATT3xFfGF0Xt7nKCICDFAKETOKEN123456789abcdef
+  JIRA_BASE_URL: https://securityphoenix.atlassian.net
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # V2: Secret exfiltration — uses ${{ secrets.* }} context
+      - name: Configure AWS
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      # V4: Artifact poisoning — publishes Docker image
+      - name: Build and Push Docker
+        run: |
+          docker build -t myregistry/app:${{ github.sha }} .
+          docker push myregistry/app:${{ github.sha }}
+
+      # V5: Lateral movement — cross-repo checkout with PAT
+      - name: Deploy to production repo
+        uses: actions/checkout@v4
+        with:
+          repository: Security-Phoenix-demo/production-configs
+          token: ${{ secrets.PAT }}
+          path: prod-configs
+
+      # Jira integration using hardcoded token
+      - name: Create Jira deployment ticket
+        run: |
+          curl -X POST "${JIRA_BASE_URL}/rest/api/3/issue" \
+            -H "Authorization: Basic $(echo -n 'ci-bot@securityphoenix.com:${JIRA_TOKEN}' | base64)" \
+            -H "Content-Type: application/json" \
+            -d '{"fields":{"project":{"key":"ASPMAIN"},"summary":"Deploy ${{ github.sha }}","issuetype":{"name":"Task"}}}'

--- a/src/main/java/org/sasanlabs/config/UnusedCredentials.java
+++ b/src/main/java/org/sasanlabs/config/UnusedCredentials.java
@@ -1,0 +1,25 @@
+package org.sasanlabs.config;
+
+/**
+ * INTENTIONALLY VULNERABLE — credentials defined but never invoked anywhere.
+ * Scanner should detect these but mark as DEFINED_ONLY (lower severity).
+ * All values are FAKE/SYNTHETIC.
+ */
+public class UnusedCredentials {
+
+    // ── SCENARIO 5: Slack bot token — defined, never used (→ HIGH, DEFINED_ONLY) ──
+    // intentionally vulnerable — CWE-798 test fixture (synthetic value)
+    public static final String SLACK_BOT_TOKEN = "xoxb-EXAMPLE_FAKE-NOT_REAL_TOKEN-SyntheticSlackBotToken123456";
+
+    // ── SCENARIO 6: GitHub PAT — defined, never passed to any client (→ HIGH, DEFINED_ONLY) ──
+    public static final String GITHUB_PAT = "github_pat_11AFAKETOKEN000000_abcDefGhiJklMnoPqrStUvWxYz0123456789AbCdEfGhIjKlMnOpQr";
+
+    // ── SCENARIO 7: OpenAI key — defined, never called (→ HIGH, DEFINED_ONLY) ──
+    public static final String OPENAI_API_KEY = "sk-proj-FAKEKEY1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZab";
+
+    // ── SCENARIO 8: Database connection string — defined, never used (→ HIGH, DEFINED_ONLY) ──
+    public static final String DATABASE_URL = "postgresql://admin:S3cretP@ssw0rd!@prod-db.internal.phoenix.io:5432/phoenix_prod";
+
+    // These are intentionally never referenced from any other class.
+    // The call graph should show zero outgoing edges from these symbols.
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/secretleak/CloudCredentialService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/secretleak/CloudCredentialService.java
@@ -1,0 +1,196 @@
+package org.sasanlabs.service.vulnerability.secretleak;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * INTENTIONALLY VULNERABLE — Exposed REST endpoints that use hardcoded cloud credentials.
+ * All credentials are FAKE/SYNTHETIC and do not grant real access.
+ *
+ * <p>Test scenarios for Phoenix Security secret scanning:
+ * <ul>
+ *   <li>INVOKED: credentials passed to external HTTP calls</li>
+ *   <li>LOGGED: credentials leaked to application logs</li>
+ *   <li>EXTERNALLY FACING: credentials reachable via public REST endpoints</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/secrets")
+public class CloudCredentialService {
+
+    private static final Logger log = LoggerFactory.getLogger(CloudCredentialService.class);
+
+    // ── SCENARIO 1: AWS key INVOKED in HTTP call (→ CRITICAL, INVOKED) ──
+    private static final String AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7TEXAMPL";
+    private static final String AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYTEXAMPLEKEY";
+
+    // ── SCENARIO 2: Jira API token INVOKED in HTTP call (→ HIGH, INVOKED) ──
+    private static final String JIRA_API_TOKEN =
+            "ATATT3xFfGF0Xt7nKqKP8R9bLzMpT3qWvN7x8yZdFAKETOKENabc123def456ghi789";
+    private static final String JIRA_EMAIL = "ci-bot@securityphoenix.com";
+    private static final String JIRA_BASE_URL = "https://securityphoenix.atlassian.net";
+
+    // ── SCENARIO 3: GCP service account key INVOKED (→ CRITICAL, INVOKED) ──
+    private static final String GCP_SERVICE_ACCOUNT_KEY =
+            "{\"type\":\"service_account\",\"project_id\":\"phoenix-sec-prod-12345\","
+                    + "\"private_key_id\":\"key123fake\","
+                    + "\"private_key\":\"-----BEGIN RSA PRIVATE KEY-----\\n"
+                    + "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8PbnGMY5aGPFAKEKEYDATA1234\\n"
+                    + "-----END RSA PRIVATE KEY-----\\n\","
+                    + "\"client_email\":\"deploy@phoenix-sec-prod-12345.iam.gserviceaccount.com\","
+                    + "\"client_id\":\"1234567890\","
+                    + "\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\","
+                    + "\"token_uri\":\"https://oauth2.googleapis.com/token\"}";
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    /**
+     * GET /api/secrets/aws/identity
+     * Calls AWS STS GetCallerIdentity — credential is INVOKED via HTTP header.
+     * Scanner: AWS key → CRITICAL, INVOKED, externally reachable.
+     */
+    @GetMapping("/aws/identity")
+    public ResponseEntity<Map<String, Object>> getAwsCallerIdentity() {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(
+                                    "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"))
+                            .header(
+                                    "Authorization",
+                                    "AWS4-HMAC-SHA256 Credential="
+                                            + AWS_ACCESS_KEY_ID
+                                            + "/us-east-1/sts/aws4_request")
+                            .header("X-Amz-Security-Token", AWS_SECRET_ACCESS_KEY)
+                            .GET()
+                            .build();
+
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            // SCENARIO 1b: credential LEAKED TO LOGS (→ PHX-CRY-010)
+            log.info(
+                    "AWS STS call with key {}: status={}",
+                    AWS_ACCESS_KEY_ID,
+                    response.statusCode());
+
+            result.put("status", response.statusCode());
+            result.put("body", response.body());
+            result.put("keyUsed", AWS_ACCESS_KEY_ID);
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * POST /api/secrets/jira/issue
+     * Creates a Jira issue — credential is INVOKED in Basic auth header.
+     * Scanner: Jira token → HIGH, INVOKED, externally reachable.
+     */
+    @PostMapping("/jira/issue")
+    public ResponseEntity<Map<String, Object>> createJiraIssue(
+            @RequestParam String projectKey, @RequestParam String summary) {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            String payload =
+                    String.format(
+                            "{\"fields\":{\"project\":{\"key\":\"%s\"},\"summary\":\"%s\","
+                                    + "\"issuetype\":{\"name\":\"Task\"}}}",
+                            projectKey, summary);
+
+            String authHeader =
+                    "Basic "
+                            + java.util.Base64.getEncoder()
+                                    .encodeToString(
+                                            (JIRA_EMAIL + ":" + JIRA_API_TOKEN)
+                                                    .getBytes());
+
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(JIRA_BASE_URL + "/rest/api/3/issue"))
+                            .header("Authorization", authHeader)
+                            .header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(payload))
+                            .build();
+
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            result.put("status", response.statusCode());
+            result.put("body", response.body());
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * GET /api/secrets/gcp/buckets
+     * Lists GCP buckets — credential is INVOKED as Bearer token.
+     * Scanner: GCP service account key → CRITICAL, INVOKED, externally reachable.
+     */
+    @GetMapping("/gcp/buckets")
+    public ResponseEntity<Map<String, Object>> listGcpBuckets() {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(
+                                    "https://storage.googleapis.com/storage/v1/b?project=phoenix-sec-prod-12345"))
+                            .header("Authorization", "Bearer " + GCP_SERVICE_ACCOUNT_KEY)
+                            .GET()
+                            .build();
+
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            result.put("status", response.statusCode());
+            result.put("body", response.body());
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * GET /api/secrets/aws/s3/list
+     * Lists S3 buckets — a second AWS endpoint to test multi-sink detection.
+     */
+    @GetMapping("/aws/s3/list")
+    public ResponseEntity<Map<String, Object>> listS3Buckets() {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create("https://s3.amazonaws.com/"))
+                            .header(
+                                    "Authorization",
+                                    "AWS " + AWS_ACCESS_KEY_ID + ":" + AWS_SECRET_ACCESS_KEY)
+                            .GET()
+                            .build();
+
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            result.put("status", response.statusCode());
+            result.put("buckets", response.body());
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/secretleak/FalsePositiveExamples.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/secretleak/FalsePositiveExamples.java
@@ -1,0 +1,33 @@
+package org.sasanlabs.service.vulnerability.secretleak;
+
+/**
+ * INTENTIONAL FALSE POSITIVES — These should be detected but classified as
+ * false positives or low severity by the AI validation layer.
+ * All values are FAKE/SYNTHETIC.
+ */
+public class FalsePositiveExamples {
+
+    // ── FP-1: Placeholder AWS key (contains "EXAMPLE" — well-known placeholder) ──
+    private static final String AWS_EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";
+
+    // ── FP-2: Stripe TEST key (sk_test_ prefix = test mode, not live) ──
+    // intentionally vulnerable — CWE-798 test fixture (synthetic value)
+    private static final String STRIPE_TEST_KEY = "sk_test_EXAMPLE_synthetic_4eC39HqLyjWDarjtT1zdp7dc";
+
+    // ── FP-3: Truncated / too-short GitHub token (structurally malformed) ──
+    private static final String BROKEN_GITHUB_TOKEN = "ghp_short";
+
+    // ── FP-4: Base64 string that LOOKS like a key but is actually a UUID ──
+    private static final String NOT_A_SECRET = "YjM4YTIxNzUtZmYxNy00Y2FhLWIzMWQtNjk1YjNl";
+
+    // ── FP-5: Variable named 'password' but value is a placeholder ──
+    private static final String DEFAULT_PASSWORD = "CHANGEME_BEFORE_DEPLOY";
+
+    // ── FP-6: Commented-out key (should be deprioritized) ──
+    // private static final String OLD_KEY = "AKIAZ7FAKE0LDKEYDATA"; // rotated 2025-01-15
+
+    // ── FP-7: API key in a test-helper method (context = test fixture, not prod) ──
+    public static String getTestApiKey() {
+        return "sk_live_THIS_IS_A_TEST_FIXTURE_NOT_REAL_00000000000";
+    }
+}

--- a/src/main/java/org/sasanlabs/service/vulnerability/secretleak/PaymentService.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/secretleak/PaymentService.java
@@ -1,0 +1,94 @@
+package org.sasanlabs.service.vulnerability.secretleak;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * INTENTIONALLY VULNERABLE — Externally-facing payment endpoints leaking Stripe credentials.
+ * All credentials are FAKE/SYNTHETIC.
+ *
+ * <p>This controller exposes TWO public endpoints that both send the Stripe secret key
+ * to Stripe's API in the Authorization header — a realistic scenario where a credential
+ * is invoked from an externally-reachable HTTP endpoint.
+ */
+@RestController
+@RequestMapping("/api/payment")
+public class PaymentService {
+
+    // ── SCENARIO 4: Stripe LIVE key in externally-facing controller (→ CRITICAL, INVOKED) ──
+    // intentionally vulnerable — CWE-798 test fixture (synthetic value)
+    private static final String STRIPE_SECRET_KEY =
+            "sk_live_[SYNTHETIC-FIXTURE-NOT-REAL]51OcR2KFAKETESTKEY9qWpN7LxZdAbCdEfGhIjKlMnOpQrSt";
+    private static final String STRIPE_API_BASE = "https://api.stripe.com/v1";
+
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    /**
+     * GET /api/payment/balance
+     * Fetches Stripe account balance — credential INVOKED in Authorization header.
+     * Scanner: Stripe live key → CRITICAL, INVOKED, externally reachable.
+     */
+    @GetMapping("/balance")
+    public ResponseEntity<Map<String, Object>> getBalance() {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(STRIPE_API_BASE + "/balance"))
+                            .header("Authorization", "Bearer " + STRIPE_SECRET_KEY)
+                            .GET()
+                            .build();
+
+            HttpResponse<String> response =
+                    client.send(request, HttpResponse.BodyHandlers.ofString());
+            result.put("status", response.statusCode());
+            result.put("balance", response.body());
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * POST /api/payment/charge
+     * Creates a Stripe charge — credential INVOKED in both header and form body.
+     * Scanner: same Stripe key, second invocation sink.
+     */
+    @PostMapping("/charge")
+    public ResponseEntity<Map<String, Object>> createCharge(
+            @RequestParam int amount, @RequestParam String currency) {
+        Map<String, Object> result = new HashMap<>();
+        try {
+            String formBody =
+                    "amount=" + amount + "&currency=" + currency + "&source=tok_visa";
+
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(STRIPE_API_BASE + "/charges"))
+                            .header("Authorization", "Bearer " + STRIPE_SECRET_KEY)
+                            .header(
+                                    "Content-Type",
+                                    "application/x-www-form-urlencoded")
+                            .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                            .build();
+
+            HttpResponse<String> response =
+                    client.send(request, HttpResponse.BodyHandlers.ofString());
+            result.put("status", response.statusCode());
+            result.put("charge", response.body());
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/resources/application-secrets.properties
+++ b/src/main/resources/application-secrets.properties
@@ -1,0 +1,19 @@
+# INTENTIONALLY VULNERABLE — Test fixture for Phoenix Security secret scanning
+# All credentials are FAKE/SYNTHETIC test values
+# Mix of invoked, unused, and false-positive credentials
+
+# SCENARIO 11: AWS key referenced by Spring @Value (→ INVOKED if wired)
+aws.accessKeyId=AKIAIOSFODNN7TEXAMPL
+aws.secretAccessKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYTEXAMPLEKEY
+
+# SCENARIO 12: Jira credentials referenced by config (→ INVOKED if wired)
+jira.api.token=ATATT3xFfGF0Xt7nKqKP8R9bLzMpT3qWvN7x8yZdFAKETOKENabc123def456ghi789
+jira.api.email=ci-bot@securityphoenix.com
+jira.api.base-url=https://securityphoenix.atlassian.net
+
+# SCENARIO 13: GCP project credentials
+gcp.project.id=phoenix-sec-prod-12345
+gcp.service-account.key-file=/etc/secrets/gcp-sa-key.json
+
+# FALSE POSITIVE: placeholder values with variable substitution
+spring.datasource.password=${DB_PASSWORD:changeme}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,22 @@
+# INTENTIONALLY VULNERABLE — Test fixture for CI/CD exploitation assessment
+# Scanner should flag: V3 (Deployment Credential Theft)
+# All credentials are FAKE/SYNTHETIC test values
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "AKIAZTESTTERRAFORM01"
+  secret_key = "wJalrXUtnFEMI/K7MDENG/TERRAFORMFAKETESTKEY1"
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "phoenix-prod-data-bucket"
+}
+
+resource "aws_iam_user" "deploy_bot" {
+  name = "deploy-bot"
+}
+
+resource "aws_iam_user_policy_attachment" "admin" {
+  user       = aws_iam_user.deploy_bot.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}


### PR DESCRIPTION
## Summary
- Adds intentionally vulnerable credential-leak endpoints and fixtures under `src/main/java/org/sasanlabs/service/vulnerability/secretleak/` (e.g. `PaymentService`, `FalsePositiveExamples`) plus unused-credential fixtures in `org.sasanlabs.config.UnusedCredentials`, covering INVOKED vs DEFINED_ONLY hardcoded-secret scenarios (Stripe, Slack, GitHub PAT, OpenAI, DB connection string) and known false-positive shapes (placeholder AWS example key, malformed/truncated tokens, base64-that-isn't-a-secret) for scanner validation.
- Adds cross-repo vulnerability levels wired through the shared `VulnerableApp-dependent` library.
- Adds README documentation for the main project and the dependent module.

## Purpose
These are intentional test fixtures for standing up a scannable, DETECTABLE-vulnerability test environment to validate the Phoenix Security scanner/hunt pipeline (secret detection, call-graph invocation classification, AI false-positive triage) - not real credentials and not an evasion exercise.

All secret-shaped literals are synthetic. Several were reworked after GitHub Push Protection flagged them as matching live provider regexes (Slack bot token, Stripe test key, Stripe/Highnote live key format) - each was made obviously non-matching to the provider's high-confidence detection regex while keeping the provider prefix and a secret-named variable recognizable, so Phoenix's own scanner can still flag them as hardcoded-credential findings. No scanner-suppression pragma was added; these are meant to be detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
