### PR TITLE
Phoenix Security Bot: automated remediation (4234dd31-0a80-4606-ba9c-5560234164b5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,25 +150,25 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.3.1.RELEASE'
 
-    runtimeOnly group:'com.h2database', name:'h2', version: '1.3.176'
+    runtimeOnly group:'com.h2database', name:'h2', version: '2.1.210'
     
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 	//Log4j Dependencies
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2'
 
     // https://mvnrepository.com/artifact/org.json/json
-    implementation group: 'org.json', name: 'json', version: '20190722'
+    implementation group: 'org.json', name: 'json', version: '20231013'
 
 	//https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.3'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.4'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
     
     implementation group: 'io.github.sasanlabs', name: 'facade-schema', version: '1.0.1'
 
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
 }
 
 test {


### PR DESCRIPTION
Automated fix proposed by Phoenix's remediation agent.

Warnings:
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2022-22965: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-1471: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-25857: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-hibernate-hibernate-core-5-4-17-final-cve-2020-25638: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- finding-aikido-org-springframework-boot-spring-boot-2-3-1-release-cve-2025-22235: stale_finding_version_not_in_dependency_graph: org.springframework.boot:spring-boot@2.3.1.RELEASE; resolved_versions=2.4.5; skipped
- finding-aikido-org-hibernate-hibernate-core-5-4-17-final-cve-2019-14900: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-38752: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-apache-commons-commons-lang3-3-9-cve-2025-48924: stale_finding_version_not_in_dependency_graph: org.apache.commons:commons-lang3@3.9; resolved_versions=3.11; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2023-20863: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2022-22950: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-41854: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-38749: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-38751: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-yaml-snakeyaml-1-26-cve-2022-38750: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2022-22970: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2022-22968: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2024-38820: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2024-38808: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2021-22060: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2021-22096: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-boot-spring-boot-autoconfigure-2-3-1-release-cve-2023-20883: stale_finding_version_not_in_dependency_graph: org.springframework.boot:spring-boot-autoconfigure@2.3.1.RELEASE; resolved_versions=2.4.5; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2023-20861: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-cve-2025-22233: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- finding-aikido-org-springframework-spring-core-5-2-7-release-aikido-2024-10363: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- ::compileClasspath: unresolved_dependency: org.sasanlabs:vulnerable-shared-lib:1.0.0
- ::runtimeClasspath: unresolved_dependency: org.sasanlabs:vulnerable-shared-lib:1.0.0
- ::testCompileClasspath: unresolved_dependency: org.sasanlabs:vulnerable-shared-lib:1.0.0
- ::testRuntimeClasspath: unresolved_dependency: org.sasanlabs:vulnerable-shared-lib:1.0.0
- compatibility_preflight_applied: gradle.bootJar.baseName.archiveBaseName
- gradle_wrapper_properties_present
- gradle_wrapper_metadata_rejected:missing_distribution_sha256_for_uncached_distribution
- gradle_execution_strategy:pinned_gradle_8
- gradle_attempt_failed:pinned_gradle_8:compatibility
- gradle_fallback_selected:pinned_gradle_7
- gradle_execution_strategy:pinned_gradle_7_fallback
- gradle_java_home_selected:pinned_gradle_7_fallback:gradle_7
