### PR TITLE
Phoenix Security Bot: This is a partial remediation with manual review required due to unresolved findings and skipped validation. (0344a2ff-b8d3-4a91-b49b-3f894f0bb615)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,21 +150,21 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.3.1.RELEASE'
 
-    runtimeOnly group:'com.h2database', name:'h2', version: '1.3.176'
+    runtimeOnly group:'com.h2database', name:'h2', version: '2.1.210'
     
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 	//Log4j Dependencies
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2'
 
     // https://mvnrepository.com/artifact/org.json/json
-    implementation group: 'org.json', name: 'json', version: '20190722'
+    implementation group: 'org.json', name: 'json', version: '20231013'
 
 	//https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.3'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation group: 'commons-io', name: 'commons-io', version: '2.7'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
     
     implementation group: 'io.github.sasanlabs', name: 'facade-schema', version: '1.0.1'
 


### PR DESCRIPTION
Automated fix proposed by Phoenix's remediation agent.

## This is a partial remediation with manual review required due to unresolved findings and skipped validation.

- Status: partial_remediation
- Confidence: low
- Breaking change risk: high
- Manual review required

### Parent/managed resolution
Some findings were not directly edited and may require reviewing transitive or managed dependency resolution.

### Stale finding assessment
Several findings for org.yaml:snakeyaml were reported at version 1.26, but the resolved version is 1.27, indicating these findings are possibly stale. Other findings for Spring Framework and QOS.ch Logback were not found in the resolved graph and may also be stale or aliases.

<details>
<summary>Dependency changes (4)</summary>

- {package=org.apache.commons:commons-text, from_version=1.8, to_version=1.10.0, changed_declaration=org.apache.commons:commons-text, changed_declaration_from_version=1.8, changed_declaration_to_version=1.10.0, resolution_source=direct, manifest_path=build.gradle, line=156}
- {package=commons-io:commons-io, from_version=2.7, to_version=2.14.0, changed_declaration=commons-io:commons-io, changed_declaration_from_version=2.7, changed_declaration_to_version=2.14.0, resolution_source=direct, manifest_path=build.gradle, line=167}
- {package=org.json:json, from_version=20190722, to_version=20231013, changed_declaration=org.json:json, changed_declaration_from_version=20190722, changed_declaration_to_version=20231013, resolution_source=direct, manifest_path=build.gradle, line=161}
- {package=com.h2database:h2, from_version=1.3.176, to_version=2.1.210, changed_declaration=com.h2database:h2, changed_declaration_from_version=1.3.176, changed_declaration_to_version=2.1.210, resolution_source=direct, manifest_path=build.gradle, line=153}

</details>

<details>
<summary>Finding statuses (25)</summary>

- {finding_id=0199306e-a968-7173-983b-2420c221141d, scanner_package=Spring Framework, scanner_version=5.2.7.RELEASE, reference_ids=[CVE-2022-22965, GHSA-36p3-wjmg-h94x, BDSA-2022-0858], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}
- {finding_id=0199306e-a979-7131-acee-10232d585e9c, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-1471, GHSA-mjmj-j48q-9wg2, BDSA-2022-3447], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-a98f-71fc-a84c-b4186d56dc67, scanner_package=com.h2database:h2, scanner_version=1.3.176, reference_ids=[CVE-2021-42392, BDSA-2022-0048], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.h2database:h2, matched_version=1.3.176, changed_declaration=com.h2database:h2, target_version=2.1.210, closest_resolved_candidates=[]}
- {finding_id=0199306e-a9a4-7008-ae6c-81f875e70f83, scanner_package=org.apache.commons:commons-text, scanner_version=1.8, reference_ids=[CVE-2022-42889, GHSA-599f-7c49-w659, BDSA-2022-2938], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.apache.commons:commons-text, matched_version=1.8, changed_declaration=org.apache.commons:commons-text, target_version=1.10.0, closest_resolved_candidates=[]}
- {finding_id=0199306e-a9bb-7e99-9026-cb7e41df1c20, scanner_package=com.h2database:h2, scanner_version=1.3.176, reference_ids=[CVE-2022-23221, GHSA-45hx-wfhj-473x, BDSA-2022-0186], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.h2database:h2, matched_version=1.3.176, changed_declaration=com.h2database:h2, target_version=2.1.210, closest_resolved_candidates=[]}
- {finding_id=0199306e-a9cf-760d-8cd6-b08b3d480e7e, scanner_package=org.json:json, scanner_version=20190722, reference_ids=[CVE-2022-45688, GHSA-3vqj-43w4-2q58, BDSA-2022-4165], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.json:json, matched_version=20190722, changed_declaration=org.json:json, target_version=20231013, closest_resolved_candidates=[]}
- {finding_id=0199306e-a9e2-7aba-938e-83b8416897cb, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-25857, GHSA-3mc7-4q67-w48m, BDSA-2022-2579], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-a9f7-7447-bd95-21a16ddbfd22, scanner_package=QOS.ch Logback, scanner_version=1.2.3, reference_ids=[CVE-2023-6378, GHSA-vmq6-5m68-f53m, BDSA-2023-3307], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=0199306e-aa09-706a-917e-e7105449a1b4, scanner_package=Connect2id Nimbus JOSE+JWT, scanner_version=8.3, reference_ids=[CVE-2023-52428, GHSA-gvpg-vgmx-xg6w, CGA-hvjw-cqfw-cqf3, BDSA-2023-3666], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[com.nimbusds:nimbus-jose-jwt@8.3]}
- {finding_id=0199306e-aa1f-7e24-919b-0cc8bf5da6fa, scanner_package=org.json:json, scanner_version=20190722, reference_ids=[CVE-2023-5072, GHSA-4jq9-2xhw-jpx7, BDSA-2023-2760], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.json:json, matched_version=20190722, changed_declaration=org.json:json, target_version=20231013, closest_resolved_candidates=[]}
- {finding_id=0199306e-aa33-7106-ad7d-9dade55d98ac, scanner_package=org.hibernate:hibernate-core, scanner_version=5.4.17.Final, reference_ids=[CVE-2020-25638, GHSA-j8jw-g6fq-mp7h, BDSA-2020-3410], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.hibernate:hibernate-core, matched_version=5.4.30.Final, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.hibernate:hibernate-core@5.4.30.Final, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.tomcat.embed:tomcat-embed-core@9.0.45, org.assertj:assertj-core@3.17.2, org.hibernate.common:hibernate-commons-annotations@5.1.2.Final]}
- {finding_id=0199306e-aa46-7cc8-9880-e6408d1e7221, scanner_package=org.springframework.boot:spring-boot, scanner_version=2.3.1.RELEASE, reference_ids=[GHSA-rc42-6c7j-7h5r, CVE-2025-22235, BDSA-2025-3548], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework.boot:spring-boot, matched_version=2.4.5, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}
- {finding_id=0199306e-aa5c-7517-be9e-24b4e697ca9a, scanner_package=QOS.ch Logback, scanner_version=1.2.3, reference_ids=[CVE-2021-42550, GHSA-668q-qrv7-99fm, BDSA-2021-3818], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=0199306e-aa73-79b6-a50f-045d08dc13ee, scanner_package=org.hibernate:hibernate-core, scanner_version=5.4.17.Final, reference_ids=[CVE-2019-14900, GHSA-8grg-q944-cch5, BDSA-2019-4479], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.hibernate:hibernate-core, matched_version=5.4.30.Final, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.hibernate:hibernate-core@5.4.30.Final, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.tomcat.embed:tomcat-embed-core@9.0.45, org.assertj:assertj-core@3.17.2, org.hibernate.common:hibernate-commons-annotations@5.1.2.Final]}
- {finding_id=0199306e-aa85-794f-93dd-463be5afcd7b, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-38752, GHSA-9w3m-gqgf-c4p9, BDSA-2022-2590], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-aa98-75ac-b121-d229ebdc92c7, scanner_package=org.apache.commons:commons-lang3, scanner_version=3.9, reference_ids=[CVE-2025-48924, GHSA-j288-q9x7-2f5v, BDSA-2025-6881], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.apache.commons:commons-lang3, matched_version=3.11, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.logging.log4j:log4j-jul@2.13.3]}
- {finding_id=0199306e-aaab-7483-902b-ccd96276db34, scanner_package=Spring Framework, scanner_version=5.2.7.RELEASE, reference_ids=[CVE-2023-20863, GHSA-558x-2xjg-6232, BDSA-2022-0820], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}
- {finding_id=0199306e-aac1-7ad8-9469-b4fa0e962b5a, scanner_package=Spring Framework, scanner_version=5.2.7.RELEASE, reference_ids=[CVE-2022-22950, GHSA-558x-2xjg-6232, BDSA-2022-0820], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}
- {finding_id=0199306e-aad4-7b3d-a4f3-167289f889d2, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-41854, GHSA-w37g-rhq8-7m4j, BDSA-2022-3211], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-aae8-7f4e-99da-a8149319134f, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-38749, GHSA-c4r9-r8fh-9vj2, BDSA-2022-2577], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-aafb-7578-9527-09c10518b6df, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-38751, GHSA-98wm-3w3q-mw94, BDSA-2022-2587], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-ab10-7bcc-805b-be4f5d97d186, scanner_package=Connect2id Nimbus JOSE+JWT, scanner_version=8.3, reference_ids=[CVE-2025-53864, GHSA-xwmg-2g98-w7v9, BDSA-2025-6849], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[com.nimbusds:nimbus-jose-jwt@8.3]}
- {finding_id=0199306e-ab23-7d97-af9e-a10e33dfabc1, scanner_package=QOS.ch Logback, scanner_version=1.2.3, reference_ids=[CVE-2024-12798, GHSA-pr98-23f8-jwxv, BDSA-2024-9866], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=0199306e-ab36-7b74-82a2-540440bb1779, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[CVE-2022-38750, GHSA-hhhw-99gj-p3c3, BDSA-2022-2578], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=0199306e-ab4a-7d8b-979a-dd17fab6be14, scanner_package=Spring Framework, scanner_version=5.2.7.RELEASE, reference_ids=[CVE-2022-22970, GHSA-hh26-6xwr-ggv7, BDSA-2022-1329], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}

</details>

<details>
<summary>Warnings (10)</summary>

- llm_summary_dependency_facts_corrected
- llm_summary_parent_resolution_corrected
- 0199306e-a979-7131-acee-10232d585e9c: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 0199306e-a9e2-7aba-938e-83b8416897cb: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 0199306e-aa33-7106-ad7d-9dade55d98ac: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- 0199306e-aa46-7cc8-9880-e6408d1e7221: stale_finding_version_not_in_dependency_graph: org.springframework.boot:spring-boot@2.3.1.RELEASE; resolved_versions=2.4.5; skipped
- 0199306e-aa73-79b6-a50f-045d08dc13ee: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- 0199306e-aa85-794f-93dd-463be5afcd7b: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 0199306e-aa98-75ac-b121-d229ebdc92c7: stale_finding_version_not_in_dependency_graph: org.apache.commons:commons-lang3@3.9; resolved_versions=3.11; skipped
- 0199306e-aad4-7b3d-a4f3-167289f889d2: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped

</details>
