### PR TITLE
Phoenix Security Bot: This is a partial remediation with manual review required due to unresolved findings and skipped validation. (b1fa2c9d-d80f-45a7-932b-061f67c1930a)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,25 +150,25 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.3.1.RELEASE'
 
-    runtimeOnly group:'com.h2database', name:'h2', version: '1.3.176'
+    runtimeOnly group:'com.h2database', name:'h2', version: '2.1.210'
     
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 	//Log4j Dependencies
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2'
 
     // https://mvnrepository.com/artifact/org.json/json
-    implementation group: 'org.json', name: 'json', version: '20190722'
+    implementation group: 'org.json', name: 'json', version: '20231013'
 
 	//https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.3'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.4'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation group: 'commons-io', name: 'commons-io', version: '2.7'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
     
     implementation group: 'io.github.sasanlabs', name: 'facade-schema', version: '1.0.1'
 
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
 }
 
 test {


### PR DESCRIPTION
Automated fix proposed by Phoenix's remediation agent.

## This is a partial remediation with manual review required due to unresolved findings and skipped validation.

- Status: partial_remediation
- Confidence: low
- Breaking change risk: high
- Manual review required

### Parent/managed resolution
No dependencies were resolved by a parent or dependency management. All changes were to direct declarations.

### Stale finding assessment
Several findings, including org.springframework:spring-core and org.yaml:snakeyaml, are possibly stale as the scanner-reported versions were not found in the effective dependency graph, but newer versions were resolved. ch.qos.logback:logback-classic findings were not found in the resolved graph and may be transitive, managed, or stale.

<details>
<summary>Dependency changes (6)</summary>

- {package=org.apache.commons:commons-text, from_version=1.8, to_version=1.10.0, changed_declaration=org.apache.commons:commons-text, changed_declaration_from_version=1.8, changed_declaration_to_version=1.10.0, resolution_source=direct, manifest_path=build.gradle, line=156}
- {package=commons-io:commons-io, from_version=2.7, to_version=2.14.0, changed_declaration=commons-io:commons-io, changed_declaration_from_version=2.7, changed_declaration_to_version=2.14.0, resolution_source=direct, manifest_path=build.gradle, line=167}
- {package=commons-fileupload:commons-fileupload, from_version=1.5, to_version=1.6.0, changed_declaration=commons-fileupload:commons-fileupload, changed_declaration_from_version=1.5, changed_declaration_to_version=1.6.0, resolution_source=direct, manifest_path=build.gradle, line=171}
- {package=org.json:json, from_version=20190722, to_version=20231013, changed_declaration=org.json:json, changed_declaration_from_version=20190722, changed_declaration_to_version=20231013, resolution_source=direct, manifest_path=build.gradle, line=161}
- {package=com.nimbusds:nimbus-jose-jwt, from_version=8.3, to_version=9.37.4, changed_declaration=com.nimbusds:nimbus-jose-jwt, changed_declaration_from_version=8.3, changed_declaration_to_version=9.37.4, resolution_source=direct, manifest_path=build.gradle, line=164}
- {package=com.h2database:h2, from_version=1.3.176, to_version=2.1.210, changed_declaration=com.h2database:h2, changed_declaration_from_version=1.3.176, changed_declaration_to_version=2.1.210, resolution_source=direct, manifest_path=build.gradle, line=153}

</details>

<details>
<summary>Finding statuses (25)</summary>

- {finding_id=019feb69-b116-7df1-8981-9107fcaa4385, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2022-0858, CVE-2022-22965, GHSA-36p3-wjmg-h94x], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}
- {finding_id=019feb69-b161-7972-84af-3f3b3d60658a, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-3447, CVE-2022-1471, GHSA-mjmj-j48q-9wg2], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b16f-7c43-8415-c4204f33a6b8, scanner_package=com.h2database:h2, scanner_version=1.3.176, reference_ids=[BDSA-2022-0048, CVE-2021-42392], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.h2database:h2, matched_version=1.3.176, changed_declaration=com.h2database:h2, target_version=2.1.210, closest_resolved_candidates=[]}
- {finding_id=019feb69-b17d-7c8c-ac9e-7784fd439d61, scanner_package=org.apache.commons:commons-text, scanner_version=1.8, reference_ids=[BDSA-2022-2938, CVE-2022-42889, GHSA-599f-7c49-w659], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.apache.commons:commons-text, matched_version=1.8, changed_declaration=org.apache.commons:commons-text, target_version=1.10.0, closest_resolved_candidates=[]}
- {finding_id=019feb69-b18d-75f3-ba0b-7117fa3e4230, scanner_package=com.h2database:h2, scanner_version=1.3.176, reference_ids=[BDSA-2022-0186, CVE-2022-23221, GHSA-45hx-wfhj-473x], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.h2database:h2, matched_version=1.3.176, changed_declaration=com.h2database:h2, target_version=2.1.210, closest_resolved_candidates=[]}
- {finding_id=019feb69-b19a-77a4-b9c0-e4708bb2acdd, scanner_package=org.json:json, scanner_version=20190722, reference_ids=[BDSA-2022-4165, CVE-2022-45688, GHSA-3vqj-43w4-2q58], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.json:json, matched_version=20190722, changed_declaration=org.json:json, target_version=20231013, closest_resolved_candidates=[]}
- {finding_id=019feb69-b1ad-7d8d-9746-9e1ac29059d2, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2579, CVE-2022-25857, GHSA-3mc7-4q67-w48m], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b1bb-7900-9e72-29a0d9fd0bc3, scanner_package=ch.qos.logback:logback-classic, scanner_version=1.2.3, reference_ids=[BDSA-2023-3307, CVE-2023-6378, GHSA-vmq6-5m68-f53m], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=019feb69-b1ca-7057-b509-9d004427d9b1, scanner_package=com.nimbusds:nimbus-jose-jwt, scanner_version=8.3, reference_ids=[BDSA-2023-3666, CGA-hvjw-cqfw-cqf3, CVE-2023-52428, GHSA-gvpg-vgmx-xg6w], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.nimbusds:nimbus-jose-jwt, matched_version=8.3, changed_declaration=com.nimbusds:nimbus-jose-jwt, target_version=9.37.4, closest_resolved_candidates=[]}
- {finding_id=019feb69-b1db-72a8-bcdf-69c56ff3b2d8, scanner_package=org.json:json, scanner_version=20190722, reference_ids=[BDSA-2023-2760, CVE-2023-5072, GHSA-4jq9-2xhw-jpx7], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.json:json, matched_version=20190722, changed_declaration=org.json:json, target_version=20231013, closest_resolved_candidates=[]}
- {finding_id=019feb69-b1ec-7817-8fb7-362f7d80fec7, scanner_package=org.hibernate:hibernate-core, scanner_version=5.4.17.Final, reference_ids=[BDSA-2020-3410, CVE-2020-25638, GHSA-j8jw-g6fq-mp7h], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.hibernate:hibernate-core, matched_version=5.4.30.Final, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.hibernate:hibernate-core@5.4.30.Final, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.tomcat.embed:tomcat-embed-core@9.0.45, org.assertj:assertj-core@3.17.2, org.hibernate.common:hibernate-commons-annotations@5.1.2.Final]}
- {finding_id=019feb69-b1ff-73dd-acae-815289da7685, scanner_package=org.springframework.boot:spring-boot, scanner_version=2.3.1.RELEASE, reference_ids=[BDSA-2025-3548, CVE-2025-22235, GHSA-rc42-6c7j-7h5r], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework.boot:spring-boot, matched_version=2.4.5, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}
- {finding_id=019feb69-b217-7252-8cdb-a0f30ced5d3f, scanner_package=ch.qos.logback:logback-classic, scanner_version=1.2.3, reference_ids=[BDSA-2021-3818, CVE-2021-42550, GHSA-668q-qrv7-99fm], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=019feb69-b229-7512-b85f-badcc7319cc1, scanner_package=org.hibernate:hibernate-core, scanner_version=5.4.17.Final, reference_ids=[BDSA-2019-4479, CVE-2019-14900, GHSA-8grg-q944-cch5], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.hibernate:hibernate-core, matched_version=5.4.30.Final, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.hibernate:hibernate-core@5.4.30.Final, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.tomcat.embed:tomcat-embed-core@9.0.45, org.assertj:assertj-core@3.17.2, org.hibernate.common:hibernate-commons-annotations@5.1.2.Final]}
- {finding_id=019feb69-b240-778e-a05e-b70da971a062, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2590, CVE-2022-38752, GHSA-9w3m-gqgf-c4p9], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b252-7e49-a301-162dc06b3c87, scanner_package=org.apache.commons:commons-lang3, scanner_version=3.9, reference_ids=[BDSA-2025-6881, CVE-2025-48924, GHSA-j288-q9x7-2f5v], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.apache.commons:commons-lang3, matched_version=3.11, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.logging.log4j:log4j-jul@2.13.3]}
- {finding_id=019feb69-b26b-7377-b43a-25443fe3670e, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2023-0847, CVE-2023-20863, GHSA-wxqc-pxw9-g2p8], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}
- {finding_id=019feb69-b284-7f40-99e4-eea3a8aed2c9, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2022-0820, CVE-2022-22950, GHSA-558x-2xjg-6232], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}
- {finding_id=019feb69-b29f-7eb2-9a22-de696224bfd2, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-3211, CVE-2022-41854, GHSA-w37g-rhq8-7m4j], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b2ba-734e-9e56-443aa0888f5b, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2577, CVE-2022-38749, GHSA-c4r9-r8fh-9vj2], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b2cd-773f-9b0c-ba46b9757d42, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2587, CVE-2022-38751, GHSA-98wm-3w3q-mw94], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b2dd-7ef4-93a9-0f579f8eaa50, scanner_package=com.nimbusds:nimbus-jose-jwt, scanner_version=8.3, reference_ids=[BDSA-2025-6849, CVE-2025-53864, GHSA-xwmg-2g98-w7v9], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.nimbusds:nimbus-jose-jwt, matched_version=8.3, changed_declaration=com.nimbusds:nimbus-jose-jwt, target_version=9.37.4, closest_resolved_candidates=[]}
- {finding_id=019feb69-b2f0-7e2c-967f-308d522a5317, scanner_package=ch.qos.logback:logback-classic, scanner_version=1.2.3, reference_ids=[BDSA-2024-9866, CVE-2024-12798, GHSA-pr98-23f8-jwxv], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=019feb69-b301-73a0-8f37-2280e8f824f3, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2578, CVE-2022-38750, GHSA-hhhw-99gj-p3c3], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb69-b310-77d3-a231-956882a8cfdd, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2022-1329, CVE-2022-22970, GHSA-hh26-6xwr-ggv7], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}

</details>

<details>
<summary>Warnings (10)</summary>

- llm_summary_dependency_facts_corrected
- 019feb69-b116-7df1-8981-9107fcaa4385: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- 019feb69-b161-7972-84af-3f3b3d60658a: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 019feb69-b1ad-7d8d-9746-9e1ac29059d2: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 019feb69-b1ec-7817-8fb7-362f7d80fec7: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- 019feb69-b1ff-73dd-acae-815289da7685: stale_finding_version_not_in_dependency_graph: org.springframework.boot:spring-boot@2.3.1.RELEASE; resolved_versions=2.4.5; skipped
- 019feb69-b229-7512-b85f-badcc7319cc1: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- 019feb69-b240-778e-a05e-b70da971a062: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 019feb69-b252-7e49-a301-162dc06b3c87: stale_finding_version_not_in_dependency_graph: org.apache.commons:commons-lang3@3.9; resolved_versions=3.11; skipped
- 019feb69-b26b-7377-b43a-25443fe3670e: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped

</details>
