### PR TITLE
Phoenix Security Bot: Partial remediation was applied, patching 9 findings, but manual review is required due to unresolved findings and potential staleness. (c9d3bd1a-4b23-492c-9db3-87eb07e14fb5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,25 +150,25 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.3.1.RELEASE'
 
-    runtimeOnly group:'com.h2database', name:'h2', version: '1.3.176'
+    runtimeOnly group:'com.h2database', name:'h2', version: '2.1.210'
     
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 	//Log4j Dependencies
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2'
 
     // https://mvnrepository.com/artifact/org.json/json
-    implementation group: 'org.json', name: 'json', version: '20190722'
+    implementation group: 'org.json', name: 'json', version: '20231013'
 
 	//https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.3'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.4'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation group: 'commons-io', name: 'commons-io', version: '2.7'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
     
     implementation group: 'io.github.sasanlabs', name: 'facade-schema', version: '1.0.1'
 
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
 }
 
 test {


### PR DESCRIPTION
Automated fix proposed by Phoenix's remediation agent.

## Partial remediation was applied, patching 9 findings, but manual review is required due to unresolved findings and potential staleness.

- Status: partial_remediation
- Confidence: low
- Breaking change risk: high
- Manual review required

### Parent/managed resolution
Some findings were not directly edited and may require reviewing transitive or managed dependency resolution.

### Stale finding assessment
Several findings, including those for org.springframework:spring-core and org.yaml:snakeyaml, are possibly stale because the scanner-reported versions were not found in the effective dependency graph. The current resolved versions are different from the scanner-reported versions.

<details>
<summary>Dependency changes (6)</summary>

- {package=org.apache.commons:commons-text, from_version=1.8, to_version=1.10.0, changed_declaration=org.apache.commons:commons-text, changed_declaration_from_version=1.8, changed_declaration_to_version=1.10.0, resolution_source=direct, manifest_path=build.gradle, line=156}
- {package=commons-io:commons-io, from_version=2.7, to_version=2.14.0, changed_declaration=commons-io:commons-io, changed_declaration_from_version=2.7, changed_declaration_to_version=2.14.0, resolution_source=direct, manifest_path=build.gradle, line=167}
- {package=commons-fileupload:commons-fileupload, from_version=1.5, to_version=1.6.0, changed_declaration=commons-fileupload:commons-fileupload, changed_declaration_from_version=1.5, changed_declaration_to_version=1.6.0, resolution_source=direct, manifest_path=build.gradle, line=171}
- {package=org.json:json, from_version=20190722, to_version=20231013, changed_declaration=org.json:json, changed_declaration_from_version=20190722, changed_declaration_to_version=20231013, resolution_source=direct, manifest_path=build.gradle, line=161}
- {package=com.nimbusds:nimbus-jose-jwt, from_version=8.3, to_version=9.37.4, changed_declaration=com.nimbusds:nimbus-jose-jwt, changed_declaration_from_version=8.3, changed_declaration_to_version=9.37.4, resolution_source=direct, manifest_path=build.gradle, line=164}
- {package=com.h2database:h2, from_version=1.3.176, to_version=2.1.210, changed_declaration=com.h2database:h2, changed_declaration_from_version=1.3.176, changed_declaration_to_version=2.1.210, resolution_source=direct, manifest_path=build.gradle, line=153}

</details>

<details>
<summary>Finding statuses (25)</summary>

- {finding_id=019feb12-7c36-7245-9526-773796575341, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2022-0858, CVE-2022-22965, GHSA-36p3-wjmg-h94x], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}
- {finding_id=019feb12-7c66-7332-a770-2544ca73818d, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-3447, CVE-2022-1471, GHSA-mjmj-j48q-9wg2], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7c72-7f26-bebf-8cc66aea6bec, scanner_package=com.h2database:h2, scanner_version=1.3.176, reference_ids=[BDSA-2022-0048, CVE-2021-42392], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.h2database:h2, matched_version=1.3.176, changed_declaration=com.h2database:h2, target_version=2.1.210, closest_resolved_candidates=[]}
- {finding_id=019feb12-7c80-72d9-be53-03f68e5a1ec8, scanner_package=org.apache.commons:commons-text, scanner_version=1.8, reference_ids=[BDSA-2022-2938, CVE-2022-42889, GHSA-599f-7c49-w659], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.apache.commons:commons-text, matched_version=1.8, changed_declaration=org.apache.commons:commons-text, target_version=1.10.0, closest_resolved_candidates=[]}
- {finding_id=019feb12-7c8d-7252-be25-92f0edfef6f9, scanner_package=com.h2database:h2, scanner_version=1.3.176, reference_ids=[BDSA-2022-0186, CVE-2022-23221, GHSA-45hx-wfhj-473x], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.h2database:h2, matched_version=1.3.176, changed_declaration=com.h2database:h2, target_version=2.1.210, closest_resolved_candidates=[]}
- {finding_id=019feb12-7c99-749a-b836-2f08f9cb1185, scanner_package=org.json:json, scanner_version=20190722, reference_ids=[BDSA-2022-4165, CVE-2022-45688, GHSA-3vqj-43w4-2q58], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.json:json, matched_version=20190722, changed_declaration=org.json:json, target_version=20231013, closest_resolved_candidates=[]}
- {finding_id=019feb12-7ca5-7d12-9a8c-7befefe95e5d, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2579, CVE-2022-25857, GHSA-3mc7-4q67-w48m], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7cb0-7420-b818-2bc4141ea6eb, scanner_package=ch.qos.logback:logback-classic, scanner_version=1.2.3, reference_ids=[BDSA-2023-3307, CVE-2023-6378, GHSA-vmq6-5m68-f53m], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=019feb12-7cbb-7c6a-8edb-e617db71d2e0, scanner_package=com.nimbusds:nimbus-jose-jwt, scanner_version=8.3, reference_ids=[BDSA-2023-3666, CGA-hvjw-cqfw-cqf3, CVE-2023-52428, GHSA-gvpg-vgmx-xg6w], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.nimbusds:nimbus-jose-jwt, matched_version=8.3, changed_declaration=com.nimbusds:nimbus-jose-jwt, target_version=9.37.4, closest_resolved_candidates=[]}
- {finding_id=019feb12-7cc8-735f-84fe-6d79e8667ee1, scanner_package=org.json:json, scanner_version=20190722, reference_ids=[BDSA-2023-2760, CVE-2023-5072, GHSA-4jq9-2xhw-jpx7], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=org.json:json, matched_version=20190722, changed_declaration=org.json:json, target_version=20231013, closest_resolved_candidates=[]}
- {finding_id=019feb12-7cd3-7bea-b395-a5d5e295b4dc, scanner_package=org.hibernate:hibernate-core, scanner_version=5.4.17.Final, reference_ids=[BDSA-2020-3410, CVE-2020-25638, GHSA-j8jw-g6fq-mp7h], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.hibernate:hibernate-core, matched_version=5.4.30.Final, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.hibernate:hibernate-core@5.4.30.Final, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.tomcat.embed:tomcat-embed-core@9.0.45, org.assertj:assertj-core@3.17.2, org.hibernate.common:hibernate-commons-annotations@5.1.2.Final]}
- {finding_id=019feb12-7ce0-7522-8659-e3ca45cd2d28, scanner_package=org.springframework.boot:spring-boot, scanner_version=2.3.1.RELEASE, reference_ids=[BDSA-2025-3548, CVE-2025-22235, GHSA-rc42-6c7j-7h5r], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework.boot:spring-boot, matched_version=2.4.5, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-jdbc@2.4.5]}
- {finding_id=019feb12-7ceb-7f3c-943c-e8f0b66e69e8, scanner_package=ch.qos.logback:logback-classic, scanner_version=1.2.3, reference_ids=[BDSA-2021-3818, CVE-2021-42550, GHSA-668q-qrv7-99fm], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=019feb12-7cf6-74a9-ae59-bba9568c536c, scanner_package=org.hibernate:hibernate-core, scanner_version=5.4.17.Final, reference_ids=[BDSA-2019-4479, CVE-2019-14900, GHSA-8grg-q944-cch5], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.hibernate:hibernate-core, matched_version=5.4.30.Final, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.hibernate:hibernate-core@5.4.30.Final, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.tomcat.embed:tomcat-embed-core@9.0.45, org.assertj:assertj-core@3.17.2, org.hibernate.common:hibernate-commons-annotations@5.1.2.Final]}
- {finding_id=019feb12-7d02-77da-af67-27254ec19bc7, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2590, CVE-2022-38752, GHSA-9w3m-gqgf-c4p9], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7d0d-7e9b-ac05-5b8066628d80, scanner_package=org.apache.commons:commons-lang3, scanner_version=3.9, reference_ids=[BDSA-2025-6881, CVE-2025-48924, GHSA-j288-q9x7-2f5v], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.apache.commons:commons-lang3, matched_version=3.11, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3, org.apache.logging.log4j:log4j-jul@2.13.3]}
- {finding_id=019feb12-7d18-79f7-bf32-adc7b58b6018, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2023-0847, CVE-2023-20863, GHSA-wxqc-pxw9-g2p8], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}
- {finding_id=019feb12-7d21-7c3d-a0e5-4179b1691dd3, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2022-0820, CVE-2022-22950, GHSA-558x-2xjg-6232], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}
- {finding_id=019feb12-7d2b-733b-a533-3c64b5615c6a, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-3211, CVE-2022-41854, GHSA-w37g-rhq8-7m4j], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7d35-79c8-bc54-2d9267a396fd, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2577, CVE-2022-38749, GHSA-c4r9-r8fh-9vj2], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7d40-7201-bddb-5c9c34758fa5, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2587, CVE-2022-38751, GHSA-98wm-3w3q-mw94], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7d4b-7cde-8d5b-130f21d1909f, scanner_package=com.nimbusds:nimbus-jose-jwt, scanner_version=8.3, reference_ids=[BDSA-2025-6849, CVE-2025-53864, GHSA-xwmg-2g98-w7v9], status=patched, reason_code=finding.covered_by_dependency_change, reason=The finding is associated with a selected dependency change., matched_package=com.nimbusds:nimbus-jose-jwt, matched_version=8.3, changed_declaration=com.nimbusds:nimbus-jose-jwt, target_version=9.37.4, closest_resolved_candidates=[]}
- {finding_id=019feb12-7d55-72e1-bedf-1d61db9becaf, scanner_package=ch.qos.logback:logback-classic, scanner_version=1.2.3, reference_ids=[BDSA-2024-9866, CVE-2024-12798, GHSA-pr98-23f8-jwxv], status=not_found_in_resolved_graph, reason_code=finding.package_not_found_in_resolved_graph, reason=The scanner package name was not found exactly in the resolved dependency graph; it may be an alias, transitive, managed, or stale., matched_package=null, matched_version=null, changed_declaration=null, target_version=null, closest_resolved_candidates=[]}
- {finding_id=019feb12-7d5f-7df9-be24-df92eda04466, scanner_package=org.yaml:snakeyaml, scanner_version=1.26, reference_ids=[BDSA-2022-2578, CVE-2022-38750, GHSA-hhhw-99gj-p3c3], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.yaml:snakeyaml, matched_version=1.27, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.yaml:snakeyaml@1.27, org.apache.commons:commons-lang3@3.11, org.apache.commons:commons-text@1.8, org.apache.logging.log4j:log4j-api@2.13.3, org.apache.logging.log4j:log4j-core@2.13.3]}
- {finding_id=019feb12-7d6a-73cd-bb4b-662600bd42b0, scanner_package=org.springframework:spring-core, scanner_version=5.2.7.RELEASE, reference_ids=[BDSA-2022-1329, CVE-2022-22970, GHSA-hh26-6xwr-ggv7], status=possibly_stale, reason_code=stale_finding_version_not_in_dependency_graph, reason=The resolver did not find the scanner-reported version in the effective dependency graph., matched_package=org.springframework:spring-core, matched_version=5.3.6, changed_declaration=null, target_version=null, closest_resolved_candidates=[org.springframework:spring-core@5.3.6, org.springframework.boot:spring-boot-autoconfigure@2.4.5, org.springframework.boot:spring-boot-dependencies@2.3.1.RELEASE, org.springframework.boot:spring-boot-starter-aop@2.4.5, org.springframework.boot:spring-boot-starter-data-jpa@2.3.1.RELEASE]}

</details>

<details>
<summary>Warnings (10)</summary>

- llm_summary_dependency_facts_corrected
- llm_summary_parent_resolution_corrected
- 019feb12-7c36-7245-9526-773796575341: stale_finding_version_not_in_dependency_graph: org.springframework:spring-core@5.2.7.RELEASE; resolved_versions=5.3.6; skipped
- 019feb12-7c66-7332-a770-2544ca73818d: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 019feb12-7ca5-7d12-9a8c-7befefe95e5d: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 019feb12-7cd3-7bea-b395-a5d5e295b4dc: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- 019feb12-7ce0-7522-8659-e3ca45cd2d28: stale_finding_version_not_in_dependency_graph: org.springframework.boot:spring-boot@2.3.1.RELEASE; resolved_versions=2.4.5; skipped
- 019feb12-7cf6-74a9-ae59-bba9568c536c: stale_finding_version_not_in_dependency_graph: org.hibernate:hibernate-core@5.4.17.Final; resolved_versions=5.4.30.Final; skipped
- 019feb12-7d02-77da-af67-27254ec19bc7: stale_finding_version_not_in_dependency_graph: org.yaml:snakeyaml@1.26; resolved_versions=1.27; skipped
- 019feb12-7d0d-7e9b-ac05-5b8066628d80: stale_finding_version_not_in_dependency_graph: org.apache.commons:commons-lang3@3.9; resolved_versions=3.11; skipped

</details>
